### PR TITLE
Harden detection of URL-driven test mode

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -2,16 +2,170 @@
 
 let adminWasPresent = false; // Initialize adminWasPresent flag
 
+function detectTestModeFromParams(params) {
+  if (!params) {
+    return false;
+  }
+
+  const truthyValues = new Set(['', '1', 'true', 'yes', 'on']);
+  const aliases = new Set(['testmode', 'testing', 'testtime', 'test']);
+
+  for (const [key, value] of params.entries()) {
+    if (!key) {
+      continue;
+    }
+
+    if (aliases.has(key.toLowerCase())) {
+      if (value == null) {
+        return true;
+      }
+
+      if (truthyValues.has(String(value).toLowerCase())) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function detectTestMode() {
+  const searchParams = new URLSearchParams(window.location.search || '');
+  if (detectTestModeFromParams(searchParams)) {
+    return true;
+  }
+
+  const rawHash = window.location.hash || '';
+  if (!rawHash) {
+    return false;
+  }
+
+  const trimmedHash = rawHash.replace(/^#/, '');
+  if (!trimmedHash) {
+    return false;
+  }
+
+  if (detectTestModeFromParams(new URLSearchParams(trimmedHash))) {
+    return true;
+  }
+
+  if (detectTestModeFromParams(new URLSearchParams(trimmedHash.startsWith('?') ? trimmedHash.slice(1) : trimmedHash))) {
+    return true;
+  }
+
+  return ['testmode', 'testing', 'testtime', 'test'].some(alias => trimmedHash.toLowerCase() === alias);
+}
+
+const testModeEnabled = detectTestMode();
+
+const testingControls = {
+  enabled: testModeEnabled,
+  overrideDayName: null,
+  overrideTimeSlot: null,
+  overrideDate: null,
+  infoElement: null,
+  changeCallbacks: [],
+  panelElement: null,
+};
+
+window.testingControls = testingControls;
+
+function registerTestingChangeCallback(callback) {
+  if (typeof callback === 'function') {
+    testingControls.changeCallbacks.push(callback);
+  }
+}
+
+function notifyTestingChange() {
+  testingControls.changeCallbacks.forEach(callback => {
+    try {
+      callback(testingControls);
+    } catch (error) {
+      console.error('Testing change callback failed:', error);
+    }
+  });
+}
+
+function getCurrentDate() {
+  const baseDate = new Date();
+
+  if (!testingControls.enabled) {
+    return baseDate;
+  }
+
+  const simulatedDate = new Date(baseDate.getTime());
+
+  if (testingControls.overrideDate) {
+    const parts = testingControls.overrideDate.split('-').map(Number);
+    if (parts.length === 3 && parts.every(part => Number.isFinite(part))) {
+      const [year, month, day] = parts;
+      simulatedDate.setFullYear(year, month - 1, day);
+    }
+  } else if (testingControls.overrideDayName) {
+    const dayNameToIndex = {
+      Sunday: 0,
+      Monday: 1,
+      Tuesday: 2,
+      Wednesday: 3,
+      Thursday: 4,
+      Friday: 5,
+      Saturday: 6,
+    };
+    const desiredIndex = dayNameToIndex[testingControls.overrideDayName];
+    if (typeof desiredIndex === 'number') {
+      const diff = desiredIndex - simulatedDate.getDay();
+      simulatedDate.setDate(simulatedDate.getDate() + diff);
+    }
+  }
+
+  if (testingControls.overrideTimeSlot) {
+    const timeSlotHour = {
+      morning: 9,
+      noon: 13,
+      evening: 18,
+      night: 22,
+    }[testingControls.overrideTimeSlot];
+
+    if (typeof timeSlotHour === 'number') {
+      simulatedDate.setHours(timeSlotHour, 0, 0, 0);
+    }
+  }
+
+  return simulatedDate;
+}
+
+window.getCurrentDate = getCurrentDate;
+
 // Initialize all components when DOM is loaded
-document.addEventListener('DOMContentLoaded', function() {
+function initializeApp() {
+  if (testingControls.enabled) {
+    setupTestingControls();
+  }
+
   // Start the clock
   initClock();
-  
+
   // Load all data sources
   loadAllData();
-  
+
   // Set up periodic refresh for dynamic data
   setupRefreshTimers();
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initializeApp);
+} else {
+  initializeApp();
+}
+
+registerTestingChangeCallback(() => {
+  updateTimeAndDate();
+  if (typeof preloadImages === 'function') {
+    preloadImages();
+  }
+  if (typeof initPhotoCarousel === 'function') {
+    initPhotoCarousel();
+  }
 });
 
 // Initialize the clock/calendar
@@ -25,7 +179,7 @@ function updateTimeAndDate() {
   const dateElement = document.getElementById('date');
   const timeElement = document.getElementById('time');
 
-  const now = new Date();
+  const now = getCurrentDate();
   /*
   // Format date as DD.MM.YYYY
   let day = String(now.getDate()).padStart(2, '0');
@@ -47,7 +201,23 @@ function updateTimeAndDate() {
   const timeString = now.toLocaleTimeString('he-IL');
   dateElement.innerHTML = dateString;
   timeElement.innerHTML = timeString;
-  
+
+  if (testingControls.enabled && testingControls.infoElement) {
+    const activeOverrides = [];
+    if (testingControls.overrideDate) {
+      activeOverrides.push(`Date: ${testingControls.overrideDate}`);
+    }
+    if (testingControls.overrideDayName) {
+      activeOverrides.push(`Day: ${testingControls.overrideDayName}`);
+    }
+    if (testingControls.overrideTimeSlot) {
+      activeOverrides.push(`Slot: ${testingControls.overrideTimeSlot}`);
+    }
+    testingControls.infoElement.textContent = activeOverrides.length
+      ? `Testing overrides → ${activeOverrides.join(' | ')}`
+      : 'Testing overrides are disabled';
+  }
+
   //document.getElementById('timeDateBox').innerHTML = formattedDateTime;
 }
 
@@ -96,9 +266,145 @@ function showError(elementId, message) {
   const element = document.getElementById(elementId);
   element.innerHTML = message || 'An error occurred';
   element.classList.add('error-state');
-  
+
   // Log to console for debugging
   console.error(`Error in ${elementId}: ${message}`);
+}
+
+function setupTestingControls() {
+  if (testingControls.panelElement) {
+    return;
+  }
+
+  const panel = document.createElement('div');
+  panel.id = 'testingControlsPanel';
+  panel.style.position = 'fixed';
+  panel.style.top = '10px';
+  panel.style.right = '10px';
+  panel.style.background = 'rgba(0, 0, 0, 0.75)';
+  panel.style.border = '1px solid #ffffff55';
+  panel.style.padding = '12px';
+  panel.style.zIndex = '9999';
+  panel.style.fontFamily = 'Arial, sans-serif';
+  panel.style.fontSize = '14px';
+  panel.style.color = '#fff';
+  panel.style.borderRadius = '8px';
+  panel.style.maxWidth = '260px';
+
+  const title = document.createElement('div');
+  title.textContent = 'Testing Controls';
+  title.style.fontWeight = 'bold';
+  title.style.marginBottom = '8px';
+  panel.appendChild(title);
+
+  const infoLine = document.createElement('div');
+  infoLine.style.fontSize = '12px';
+  infoLine.style.marginBottom = '8px';
+  infoLine.textContent = 'Testing overrides are disabled';
+  panel.appendChild(infoLine);
+  testingControls.infoElement = infoLine;
+
+  const createField = (labelText, inputElement) => {
+    const wrapper = document.createElement('label');
+    wrapper.style.display = 'block';
+    wrapper.style.marginBottom = '6px';
+
+    const label = document.createElement('span');
+    label.textContent = labelText;
+    label.style.display = 'block';
+    label.style.marginBottom = '2px';
+
+    wrapper.appendChild(label);
+    wrapper.appendChild(inputElement);
+    panel.appendChild(wrapper);
+  };
+
+  const dateInput = document.createElement('input');
+  dateInput.type = 'date';
+  dateInput.style.width = '100%';
+  dateInput.addEventListener('change', event => {
+    testingControls.overrideDate = event.target.value || null;
+
+    if (testingControls.overrideDate) {
+      const selectedDate = new Date(`${testingControls.overrideDate}T00:00:00`);
+      if (!Number.isNaN(selectedDate.getTime())) {
+        const dayName = selectedDate.toLocaleString('en-US', { weekday: 'long' });
+        testingControls.overrideDayName = dayName;
+        daySelect.value = dayName;
+      }
+    }
+
+    notifyTestingChange();
+  });
+
+  createField('Override date', dateInput);
+
+  const daySelect = document.createElement('select');
+  daySelect.style.width = '100%';
+  ['', 'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+    .forEach(dayName => {
+      const option = document.createElement('option');
+      option.value = dayName || '';
+      option.textContent = dayName || 'Current day';
+      daySelect.appendChild(option);
+    });
+
+  daySelect.addEventListener('change', event => {
+    testingControls.overrideDayName = event.target.value || null;
+    if (!event.target.value) {
+      if (testingControls.overrideDate) {
+        testingControls.overrideDate = null;
+        dateInput.value = '';
+      }
+    }
+    notifyTestingChange();
+  });
+
+  createField('Override day of week', daySelect);
+
+  const timeSlotSelect = document.createElement('select');
+  timeSlotSelect.style.width = '100%';
+  ['', 'morning', 'noon', 'evening', 'night'].forEach(slot => {
+    const option = document.createElement('option');
+    option.value = slot;
+    option.textContent = slot ? slot.charAt(0).toUpperCase() + slot.slice(1) : 'Current slot';
+    timeSlotSelect.appendChild(option);
+  });
+
+  timeSlotSelect.addEventListener('change', event => {
+    testingControls.overrideTimeSlot = event.target.value || null;
+    notifyTestingChange();
+  });
+
+  createField('Override time slot', timeSlotSelect);
+
+  const resetButton = document.createElement('button');
+  resetButton.type = 'button';
+  resetButton.textContent = 'Reset overrides';
+  resetButton.style.marginTop = '6px';
+  resetButton.style.width = '100%';
+  resetButton.style.padding = '6px';
+  resetButton.style.border = 'none';
+  resetButton.style.borderRadius = '4px';
+  resetButton.style.cursor = 'pointer';
+  resetButton.style.background = '#2c7be5';
+  resetButton.style.color = '#fff';
+
+  resetButton.addEventListener('click', () => {
+    testingControls.overrideDate = null;
+    testingControls.overrideDayName = null;
+    testingControls.overrideTimeSlot = null;
+    dateInput.value = '';
+    daySelect.value = '';
+    timeSlotSelect.value = '';
+    notifyTestingChange();
+  });
+
+  panel.appendChild(resetButton);
+
+  document.body.appendChild(panel);
+  testingControls.panelElement = panel;
+  notifyTestingChange();
 }
 
 // Refresh the page every 60 minutes (adjust as needed)

--- a/js/photo-carousel.js
+++ b/js/photo-carousel.js
@@ -63,7 +63,13 @@ if (!window.photoHolidaySchedule) {
 
 // Function to get the current time slot
 function getTimeSlot() {
-  const now = new Date();
+  const testing = window.testingControls;
+  if (testing?.enabled && testing.overrideTimeSlot) {
+    console.log(`getTimeSlot(): Using testing override ${testing.overrideTimeSlot}`);
+    return testing.overrideTimeSlot;
+  }
+
+  const now = typeof window.getCurrentDate === 'function' ? window.getCurrentDate() : new Date();
   const hour = now.getHours();
   console.log(`getTimeSlot(): hour:${hour}, now: ${now}`);
   if (hour >= 20 || hour < 5) return "night";    // 20:00 - 04:59
@@ -74,8 +80,11 @@ function getTimeSlot() {
 
 
 function getHolidayPhotos() {
-  const now = new Date();
-  const isoDate = now.toISOString().split('T')[0];
+  const now = typeof window.getCurrentDate === 'function' ? window.getCurrentDate() : new Date();
+  const testing = window.testingControls;
+  const isoDate = testing?.enabled && testing.overrideDate
+    ? testing.overrideDate
+    : now.toISOString().split('T')[0];
   const timeSlot = getTimeSlot();
   const holidaySchedule = window.photoHolidaySchedule || {};
   const holidayForToday = holidaySchedule[isoDate];
@@ -112,8 +121,18 @@ function getHolidayPhotos() {
 
 // Function to get today's photo set
 function getTodayPhotos() {
-  const now = new Date();
-  const dayName = now.toLocaleString('en-US', { weekday: 'long' });
+  const testing = window.testingControls;
+  let dayName = null;
+
+  if (testing?.enabled && testing.overrideDayName) {
+    dayName = testing.overrideDayName;
+  }
+
+  if (!dayName) {
+    const now = typeof window.getCurrentDate === 'function' ? window.getCurrentDate() : new Date();
+    dayName = now.toLocaleString('en-US', { weekday: 'long' });
+  }
+
   const timeSlot = getTimeSlot();
   console.log(`getTodayPhotos(): timeSlot:${timeSlot}, dayName: ${dayName}`);
   const holidayPhotos = getHolidayPhotos();


### PR DESCRIPTION
## Summary
- broaden test mode detection to accept case-insensitive URL parameters and hash flags
- initialize testing controls immediately when the page is already loaded and avoid duplicate panels

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d42a640b8c83299ed8bc9721232708