### PR TITLE
Hide resolution indicator outside testing mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Header / Title -->
   <div class="header-title">YAKINTON 46</div>
 
-  <!--<div class="device-resolution" id="resolutionBox"></div>-->
+  <div class="device-resolution" id="resolutionBox" style="display: none;"></div>
 
   <!-- Time and date -->
   <div class="time-and-date" id="timeDateBox">

--- a/js/main.js
+++ b/js/main.js
@@ -399,18 +399,26 @@ function checkForRemoteRefresh() {
       })
       .catch(error => console.error("Error checking refresh status:", error));
 }
-/*
 function updateResolution() {
+  const resolutionElement = document.getElementById('resolutionBox');
+  if (!resolutionElement) {
+    return;
+  }
+
+  if (!testingControls.enabled) {
+    resolutionElement.textContent = '';
+    resolutionElement.style.display = 'none';
+    return;
+  }
+
   const width = window.innerWidth;
   const height = window.innerHeight;
-  document.getElementById('resolutionBox').innerHTML = `Resolution: ${width} x ${height}`;
+  resolutionElement.style.display = 'block';
+  resolutionElement.textContent = `Resolution: ${width} x ${height}`;
 }
 
-
-// Update resolution on load and when window resizes
-document.addEventListener('DOMContentLoaded', updateResolution);*/
-//
-// Compare this snippet from js/data-sync.js:
+// Update resolution on load and when the window resizes
+document.addEventListener('DOMContentLoaded', updateResolution);
 window.addEventListener('resize', updateResolution);
 
 // Check for Admin presence


### PR DESCRIPTION
## Summary
- hide the resolution indicator element by default in the main layout
- gate resolution updates so they only show when testing mode is enabled

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2332062f8832983de52c63a1a5a04