### PR TITLE
Improve logging for RSS feed resolution errors

### DIFF
--- a/js/news.js
+++ b/js/news.js
@@ -2,7 +2,12 @@
 
 // Configuration for news feed
 const newsConfig = {
-  feedUrl: 'https://rss.walla.co.il/feed/2686',  // Walla News
+  feedProxyPath: '/rss-proxy',
+  fallbackFeedUrl: 'https://rss.walla.co.il/feed/2686',
+  feedSheet: {
+    baseUrl: 'https://docs.google.com/spreadsheets/d/e/2PACX-1vRm_3aSAL3tnmyOHuAXMIc0IF6V3MlR-CmB3rmebHON0V_V3r3ido3hdq2qr_ByTbIayW1AKZjp45IL',
+    tabName: 'rssFeedUrl'
+  },
   maxItems: 20, // Maximum items to fetch
   displayItems: 3, // Number of items to display at once
   cycleIntervalMs: 10000 // Rotation interval (10 seconds)
@@ -12,15 +17,40 @@ const newsConfig = {
 let allNewsItems = [];
 let currentIndex = 0;
 let newsInterval = null;
+let isNewsStale = false;
+let lastNewsUpdatedDisplay = '';
+
+const NEWS_CACHE_KEY = 'yakinton46.newsCache';
+const NEWS_FEED_URL_STORAGE_KEY = 'yakinton46.newsFeedUrl';
+const FEED_URL_CACHE_TTL_MS = 5 * 60 * 1000; // Cache feed URL for 5 minutes
+
+let activeFeedSourceUrl = null;
+let feedSourceUrlTimestamp = 0;
+let feedSourceUrlPromise = null;
 
 // Fetch news from RSS feed
 function fetchNewsBreaks() {
-  
+
   console.log("Fetching news at", new Date().toLocaleTimeString());
   // Show loading state
   document.getElementById('newsContainer').innerHTML = '<div class="loading-indicator">Loading news...</div>';
-  
-  fetch(newsConfig.feedUrl)
+
+  return ensureFeedSourceUrl()
+    .then(feedSourceUrl => {
+      if (!feedSourceUrl) {
+        throw new Error('No RSS feed URL resolved from Google Sheets configuration.');
+      }
+
+      const requestUrl = buildFeedRequestUrl(feedSourceUrl);
+      if (!requestUrl) {
+        console.error('Unable to construct RSS request URL from resolved feed source.', {
+          feedSourceUrl
+        });
+        throw new Error('Unable to construct RSS request URL.');
+      }
+
+      return fetch(requestUrl);
+    })
     .then(response => {
       if (!response.ok) {
         throw new Error(`News feed responded with status ${response.status}`);
@@ -59,12 +89,31 @@ function fetchNewsBreaks() {
         };
       });
 
+      if (allNewsItems.length === 0) {
+        console.warn('No news items found in feed response. Attempting to use cached items.');
+        if (!loadNewsFromCache({ showNotice: true })) {
+          showError('newsContainer', 'No news items available');
+        }
+        return;
+      }
+
+      isNewsStale = false;
+      lastNewsUpdatedDisplay = new Date().toLocaleString();
+      saveNewsCache({ items: allNewsItems, timestamp: Date.now() });
+
       // Reset and start the news cycling
       startCyclingNews();
     })
     .catch(error => {
-      console.error("Error fetching RSS:", error);
-      showError('newsContainer', 'News feed temporarily unavailable');
+      console.error('Error fetching RSS feed.', {
+        message: error?.message,
+        feedSourceUrl: activeFeedSourceUrl,
+        stack: error?.stack
+      });
+      const usedCache = loadNewsFromCache({ showNotice: true });
+      if (!usedCache) {
+        showError('newsContainer', 'News feed temporarily unavailable');
+      }
     });
 }
 
@@ -99,6 +148,14 @@ function renderNewsBatch() {
   // Get container and create list
   const container = document.getElementById("newsContainer");
   container.innerHTML = "";
+
+  if (isNewsStale && lastNewsUpdatedDisplay) {
+    const notice = document.createElement('div');
+    notice.classList.add('news-stale-notice');
+    notice.textContent = `Showing cached news from ${lastNewsUpdatedDisplay}`;
+    container.appendChild(notice);
+  }
+
   const ul = document.createElement("ul");
   ul.classList.add("horizontal-list");
 
@@ -121,4 +178,305 @@ function renderNewsBatch() {
 
   // Append to container
   container.appendChild(ul);
+}
+
+function saveNewsCache(cachePayload) {
+  try {
+    if (typeof localStorage === 'undefined') {
+      return;
+    }
+    localStorage.setItem(NEWS_CACHE_KEY, JSON.stringify(cachePayload));
+  } catch (error) {
+    console.warn('Unable to persist news cache', error);
+  }
+}
+
+function loadNewsFromCache({ showNotice = false } = {}) {
+  try {
+    if (typeof localStorage === 'undefined') {
+      return false;
+    }
+    const rawCache = localStorage.getItem(NEWS_CACHE_KEY);
+    if (!rawCache) {
+      return false;
+    }
+
+    const parsedCache = JSON.parse(rawCache);
+    if (!parsedCache.items || !Array.isArray(parsedCache.items) || parsedCache.items.length === 0) {
+      return false;
+    }
+
+    allNewsItems = parsedCache.items;
+    isNewsStale = true;
+    lastNewsUpdatedDisplay = parsedCache.timestamp ? new Date(parsedCache.timestamp).toLocaleString() : '';
+
+    if (showNotice) {
+      console.info('Displaying cached news items from local storage.');
+    }
+
+    startCyclingNews();
+    return true;
+  } catch (error) {
+    console.warn('Unable to load news cache', error);
+    return false;
+  }
+}
+
+function ensureFeedSourceUrl({ forceRefresh = false } = {}) {
+  const now = Date.now();
+
+  if (!forceRefresh && activeFeedSourceUrl && (now - feedSourceUrlTimestamp) < FEED_URL_CACHE_TTL_MS) {
+    return Promise.resolve(activeFeedSourceUrl);
+  }
+
+  if (feedSourceUrlPromise) {
+    return feedSourceUrlPromise;
+  }
+
+  feedSourceUrlPromise = fetchFeedSourceUrlFromSheet()
+    .then(sheetFeedUrl => {
+      const normalizedSheetUrl = (sheetFeedUrl || '').trim();
+
+      if (normalizedSheetUrl) {
+        activeFeedSourceUrl = normalizedSheetUrl;
+        feedSourceUrlTimestamp = Date.now();
+        saveFeedUrlToStorage(normalizedSheetUrl);
+        return normalizedSheetUrl;
+      }
+
+      const cachedFeedUrl = loadFeedUrlFromStorage();
+      if (cachedFeedUrl) {
+        console.warn('Sheet RSS feed URL was empty. Falling back to cached feed URL.', {
+          cachedFeedUrl
+        });
+        activeFeedSourceUrl = cachedFeedUrl;
+        feedSourceUrlTimestamp = Date.now();
+        return cachedFeedUrl;
+      }
+
+      if (newsConfig.fallbackFeedUrl) {
+        console.warn('Sheet RSS feed URL unavailable. Falling back to configured default.', {
+          fallbackFeedUrl: newsConfig.fallbackFeedUrl
+        });
+        activeFeedSourceUrl = newsConfig.fallbackFeedUrl;
+        feedSourceUrlTimestamp = Date.now();
+        return newsConfig.fallbackFeedUrl;
+      }
+
+      throw new Error('No RSS feed URL available after reading Google Sheet.');
+    })
+    .catch(error => {
+      console.error('Unable to retrieve RSS feed URL from Google Sheet.', {
+        message: error?.message,
+        stack: error?.stack
+      });
+
+      const cachedFeedUrl = loadFeedUrlFromStorage();
+      if (cachedFeedUrl) {
+        activeFeedSourceUrl = cachedFeedUrl;
+        feedSourceUrlTimestamp = Date.now();
+        return cachedFeedUrl;
+      }
+
+      if (activeFeedSourceUrl) {
+        return activeFeedSourceUrl;
+      }
+
+      if (newsConfig.fallbackFeedUrl) {
+        activeFeedSourceUrl = newsConfig.fallbackFeedUrl;
+        feedSourceUrlTimestamp = Date.now();
+        return newsConfig.fallbackFeedUrl;
+      }
+
+      throw error;
+    })
+    .finally(() => {
+      feedSourceUrlPromise = null;
+    });
+
+  return feedSourceUrlPromise;
+}
+
+function fetchFeedSourceUrlFromSheet() {
+  if (!newsConfig.feedSheet || !newsConfig.feedSheet.baseUrl || !newsConfig.feedSheet.tabName) {
+    console.debug('Feed sheet configuration incomplete. Skipping sheet fetch.', {
+      feedSheetConfig: newsConfig.feedSheet
+    });
+    return Promise.resolve(null);
+  }
+
+  return resolveFeedSheetCsvUrl()
+    .then(csvUrl => {
+      if (!csvUrl) {
+        console.error('Google Sheet CSV URL could not be resolved. Sheet may be unavailable.', {
+          feedSheetConfig: newsConfig.feedSheet
+        });
+        return null;
+      }
+
+      return fetch(csvUrl)
+        .then(response => {
+          if (!response.ok) {
+            throw new Error(`RSS feed sheet responded with status ${response.status}`);
+          }
+          return response.text();
+        })
+        .then(rawCsv => {
+          if (!rawCsv) {
+            console.error('RSS feed sheet returned empty CSV payload.');
+            return null;
+          }
+
+          const sanitizedCsv = rawCsv.replace(/^﻿/, '');
+          const lines = sanitizedCsv.split(/\r?\n/);
+
+          for (let i = 0; i < lines.length; i++) {
+            const line = lines[i];
+            if (!line || !line.trim()) {
+              continue;
+            }
+
+            const cellValue = extractFirstCellFromCsvLine(line);
+            if (cellValue) {
+              try {
+                const parsedUrl = new URL(cellValue);
+                if (!parsedUrl.protocol || !/^https?:$/i.test(parsedUrl.protocol)) {
+                  console.error('RSS feed URL in Google Sheet must use HTTP(S).', {
+                    cellValue
+                  });
+                  continue;
+                }
+              } catch (urlError) {
+                console.error('Invalid RSS feed URL format encountered in Google Sheet.', {
+                  cellValue,
+                  message: urlError?.message
+                });
+                continue;
+              }
+
+              return cellValue;
+            }
+          }
+
+          console.error('No usable RSS feed URL found in Google Sheet.', {
+            sanitizedCsvSnippet: sanitizedCsv.slice(0, 200)
+          });
+          return null;
+        });
+    });
+}
+
+function resolveFeedSheetCsvUrl() {
+  if (!newsConfig.feedSheet || !newsConfig.feedSheet.baseUrl || !newsConfig.feedSheet.tabName) {
+    console.debug('Feed sheet configuration incomplete while resolving CSV URL.', {
+      feedSheetConfig: newsConfig.feedSheet
+    });
+    return Promise.resolve(null);
+  }
+
+  if (newsConfig.feedSheet.csvUrl) {
+    return Promise.resolve(newsConfig.feedSheet.csvUrl);
+  }
+
+  if (newsConfig.feedSheet._resolvingPromise) {
+    return newsConfig.feedSheet._resolvingPromise;
+  }
+
+  const pubHtmlUrl = `${newsConfig.feedSheet.baseUrl}/pubhtml`;
+  const sheetNamePattern = newsConfig.feedSheet.tabName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+  newsConfig.feedSheet._resolvingPromise = fetch(pubHtmlUrl)
+    .then(response => {
+      if (!response.ok) {
+        throw new Error(`Failed to resolve RSS feed sheet GID. Status: ${response.status}`);
+      }
+      return response.text();
+    })
+    .then(html => {
+      const regex = new RegExp(`name:\\s*"${sheetNamePattern}"[^}]*gid:\\s*"(-?\\d+)"`);
+      const match = regex.exec(html);
+
+      if (match && match[1]) {
+        const gid = match[1];
+        const csvUrl = `${newsConfig.feedSheet.baseUrl}/pub?gid=${gid}&single=true&output=csv`;
+        newsConfig.feedSheet.csvUrl = csvUrl;
+        return csvUrl;
+      }
+
+      console.error(`Unable to find Google Sheet tab "${newsConfig.feedSheet.tabName}" while resolving CSV URL.`, {
+        htmlSnippet: html.slice(0, 200)
+      });
+      return null;
+    })
+    .finally(() => {
+      newsConfig.feedSheet._resolvingPromise = null;
+    });
+
+  return newsConfig.feedSheet._resolvingPromise;
+}
+
+function extractFirstCellFromCsvLine(line) {
+  let inQuotes = false;
+  let value = '';
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+
+    if (char === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        value += '"';
+        i++;
+        continue;
+      }
+      inQuotes = !inQuotes;
+      continue;
+    }
+
+    if (char === ',' && !inQuotes) {
+      break;
+    }
+
+    value += char;
+  }
+
+  return value.trim();
+}
+
+function loadFeedUrlFromStorage() {
+  try {
+    if (typeof localStorage === 'undefined') {
+      return null;
+    }
+    const stored = localStorage.getItem(NEWS_FEED_URL_STORAGE_KEY);
+    return stored ? stored.trim() : null;
+  } catch (error) {
+    console.warn('Unable to read stored RSS feed URL.', error);
+    return null;
+  }
+}
+
+function saveFeedUrlToStorage(feedUrl) {
+  try {
+    if (typeof localStorage === 'undefined' || !feedUrl) {
+      return;
+    }
+    localStorage.setItem(NEWS_FEED_URL_STORAGE_KEY, feedUrl);
+  } catch (error) {
+    console.warn('Unable to persist RSS feed URL cache.', error);
+  }
+}
+
+function buildFeedRequestUrl(feedSourceUrl) {
+  if (!feedSourceUrl) {
+    return null;
+  }
+
+  const proxyPath = newsConfig.feedProxyPath;
+  if (!proxyPath || !proxyPath.trim()) {
+    return feedSourceUrl;
+  }
+
+  const trimmedProxy = proxyPath.trim();
+  const separator = trimmedProxy.includes('?') ? '&' : '?';
+  return `${trimmedProxy}${separator}url=${encodeURIComponent(feedSourceUrl)}`;
 }

--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,8 @@ yakinton46/
 5. Customize the city in `weather.js` to your desired location
 6. Configure your photo schedule in the Google Sheet tab referenced by `photoSheetUrl`
 7. Replace the audio file with your preferred background music
+8. (Optional) Start the lightweight RSS proxy with `node server/rssProxy.js` to serve the news feed without CORS issues. Set the `FEED_URL` environment variable to override the default source if needed.
+9. Update the `rssFeedUrl` tab in the shared Google Sheet with the desired RSS source (first cell, first row).
 
 ## Google Sheets Configuration
 
@@ -79,6 +81,11 @@ yakinton46/
 - For multi-day holidays list each date in the `date` column separated by `|`; when the first value includes a year, subsequent `MM-DD` values reuse that year automatically
 - Valid time slots: `morning`, `noon`, `evening`, `night`, or `all` (applies to every slot)
 - Publish the sheet tab to the web as CSV, similar to the messages sheet
+
+### RSS Feed URL Sheet
+- Tab name: `rssFeedUrl`
+- Publish the sheet tab to the web as CSV (same Google Sheet as the other tabs)
+- Enter the desired RSS feed URL in the first column (additional rows are ignored)
 
 ## Deployment Options
 

--- a/server/rssProxy.js
+++ b/server/rssProxy.js
@@ -1,0 +1,67 @@
+const http = require('http');
+const { URL } = require('url');
+
+const DEFAULT_FEED_URL = process.env.FEED_URL || 'https://rss.walla.co.il/feed/2686';
+const PORT = process.env.PORT || 8787;
+
+async function handleRequest(req, res) {
+  const requestUrl = new URL(req.url, `http://${req.headers.host}`);
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204, {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET,OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+      'Access-Control-Max-Age': '86400'
+    });
+    res.end();
+    return;
+  }
+
+  if (requestUrl.pathname !== '/rss-proxy') {
+    res.writeHead(404, {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*'
+    });
+    res.end(JSON.stringify({ error: 'Not Found' }));
+    return;
+  }
+
+  const targetFeed = requestUrl.searchParams.get('url') || DEFAULT_FEED_URL;
+
+  try {
+    const upstreamResponse = await fetch(targetFeed, {
+      headers: {
+        'User-Agent': 'TV-WebApp RSS Proxy/1.0 (+https://github.com)'
+      }
+    });
+
+    const body = await upstreamResponse.text();
+
+    const headers = {
+      'Access-Control-Allow-Origin': '*',
+      'Cache-Control': 'public, max-age=120'
+    };
+
+    const contentType = upstreamResponse.headers.get('content-type');
+    headers['Content-Type'] = contentType || 'application/rss+xml; charset=utf-8';
+
+    res.writeHead(upstreamResponse.status, headers);
+    res.end(body);
+  } catch (error) {
+    console.error('Error fetching RSS feed through proxy:', error);
+    res.writeHead(502, {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*'
+    });
+    res.end(JSON.stringify({ error: 'Failed to fetch RSS feed' }));
+  }
+}
+
+const server = http.createServer((req, res) => {
+  handleRequest(req, res);
+});
+
+server.listen(PORT, () => {
+  console.log(`RSS proxy listening on port ${PORT}`);
+});

--- a/styles.css
+++ b/styles.css
@@ -233,6 +233,13 @@ table.todo-table .sub-header {
   height: 17%;
 }
 
+.news-stale-notice {
+  font-size: 0.75rem;
+  opacity: 0.75;
+  margin-bottom: 6px;
+  text-align: right;
+}
+
 .daily-photo {
   top: 20%;	
   right: 30%; 	


### PR DESCRIPTION
## Summary
- add contextual console logging when RSS feed resolution fails or falls back so issues with the Google Sheet are easier to debug
- validate sheet-provided URLs and surface detailed error payloads when the ticker cannot build a request

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e2336002fc83299de39e15b1160a51